### PR TITLE
Fix boat list key

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,7 +3,8 @@ fetch('public/dgbr2025/RaceSetup.json')
   .then(r => r.json())
   .then(data => {
     const ul = document.getElementById('boatlist');
-    data.boats.forEach(b => {
+    const BOATS_KEY = 'teams';
+    data[BOATS_KEY].forEach(b => {
       const li = document.createElement('li');
       li.textContent = b.name;
       ul.appendChild(li);


### PR DESCRIPTION
## Summary
- fetch boat names from the `teams` array instead of the missing `boats` array

## Testing
- `node -e "require('./app.js')"` *(fails: window is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68459f32e7f08324871423ed06fc5857