### PR TITLE
Add data filtering toggle with dynamic speed processing

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,9 +11,14 @@
 
   <!-- Boat chooser -->
   <label for="boatSelect">Choose a boat:</label>
-  <select id="boatSelect">
-    <option value="" selected disabled>Loading...</option>
+  <select id="boatSelect" disabled>
+    <option>Loading…</option>
   </select>
+
+  <label style="margin-left:2rem">
+    <input type="checkbox" id="rawToggle">
+    Show raw points
+  </label>
 
   <!-- Chart area -->
   <h2 id="chartTitle" style="margin-top:2rem"></h2>


### PR DESCRIPTION
## Summary
- allow user to toggle raw vs filtered data in UI
- compute maximum speed per boat dynamically
- filter GPS glitches and apply optional smoothing

## Testing
- `node -v`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6845b0beb55c83249fad6784d7124d19