### PR TITLE
Fix duplicate key variable

### DIFF
--- a/app.js
+++ b/app.js
@@ -101,8 +101,8 @@ async function init () {
     }
 
     function drawClass () {
-      const key = classSelect.value;
-      if (key && classInfo[key]) plotClass(key, !rawToggle.checked);
+      const classKey = classSelect.value;
+      if (classKey && classInfo[classKey]) plotClass(classKey, !rawToggle.checked);
     }
 
   } catch (err) {


### PR DESCRIPTION
## Summary
- rename the second `key` variable to `classKey` so variables aren't redeclared

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_6845fe9431388324bcb8b39ea4a4c386