### PR TITLE
Fix time axis dataset parsing

### DIFF
--- a/app.js
+++ b/app.js
@@ -179,7 +179,7 @@ function plotClass (classKey, filtered) {
     data:{ datasets },
     options:{
       responsive:true,
-      parsing:false,
+      // parsing:false,
       scales:{
         x:{ type:'time', time:{ unit:'hour' } },
         y:{ title:{ display:true, text:'knots' } }


### PR DESCRIPTION
## Summary
- chart.js uses default parsing to handle date objects
- comment out custom parsing option in `plotClass`

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6846013a10c483249eaf4cf1d065d2dc