### PR TITLE
Add zoom support and color palette

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,11 @@
   <title>Coach Regatta</title>
   <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns@3"></script>
+  <!-- Colour helpers (optional but handy for palettes) -->
+  <script src="https://cdn.jsdelivr.net/npm/chroma-js@2"></script>
+
+  <!-- Zoom / pan for Chart.js 4 -->
+  <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom@2.0.1/dist/chartjs-plugin-zoom.umd.min.js"></script>
 </head>
 <body>
   <h1>De Guingand Bowl Race 2025 – Boat analysis</h1>


### PR DESCRIPTION
## Summary
- include chroma.js and chartjs-plugin-zoom on page
- provide `getColor` helper for consistent colours
- improve datasets in class comparison plot
- add grid, interaction and zoom/legend options for better charts

## Testing
- `node -c app.js`

------
https://chatgpt.com/codex/tasks/task_e_684604581e5c8324aefbabdd3feb1ea5