### PR TITLE
Add leaderboard and sector analysis tables

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,9 +35,17 @@
     Show raw points
   </label>
 
-  <!-- Chart area -->
-  <h2 id="chartTitle" style="margin-top:2rem"></h2>
-  <canvas id="speedChart" width="900" height="400"></canvas>
+  <!-- Chart and leaderboard area -->
+  <div id="main-content-container" style="display:flex; gap:2rem; align-items:flex-start; margin-top:2rem;">
+    <div id="chart-container">
+      <h2 id="chartTitle"></h2>
+      <canvas id="speedChart" width="900" height="400"></canvas>
+    </div>
+    <div id="leaderboard-container"></div>
+  </div>
+
+  <!-- Sector analysis area -->
+  <div id="sector-analysis-container" style="margin-top:2rem;"></div>
 
   <script src="app.js" defer></script>
 </body>


### PR DESCRIPTION
## Summary
- show leaderboard and sector analysis containers on the page
- load leaderboard data and display it filtered by class
- compute per-sector statistics for a selected boat

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6846b5dbd3b48324bca48fd19e8cf495