### PR TITLE
fix: deduplicate position fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [Unreleased]
+### Fixed
+- deduplicate position fixes when loading races

--- a/app.js
+++ b/app.js
@@ -1,4 +1,5 @@
 /* global Chart */
+import { parsePositions } from './parsePositions.mjs';
 
 // ---------- CONFIG ----------
 const DIST_GLITCH_NM = 2;     // >2 nm jump in one fix = bad GPS
@@ -113,7 +114,7 @@ async function loadRace(raceId) {
         /* 2.  positions file  ---------------------------------------------- */
         // AllPositions3.json is an ARRAY of { id, moments:[…] }
         const boats = await fetchJSON(POS_URL);
-        boats.forEach(b => { positionsByBoat[b.id] = b.moments; });
+        positionsByBoat = parsePositions(boats);
 
         /* 2b. leaderboard data -------------------------------------------- */
         const lbJSON = await fetchJSON(LEADER_URL);

--- a/index.html
+++ b/index.html
@@ -47,6 +47,6 @@
   <!-- Sector analysis area -->
   <div id="sector-analysis-container" style="margin-top:2rem;"></div>
 
-  <script src="app.js" defer></script>
+  <script type="module" src="app.js"></script>
 </body>
 </html>

--- a/parsePositions.mjs
+++ b/parsePositions.mjs
@@ -1,0 +1,39 @@
+export const EPSILON_NM = 0.001;
+const R_EARTH_NM = 3440.065;
+const deg2rad = d => d*Math.PI/180;
+export function haversineNm(la1,lo1,la2,lo2){
+  const phi1=deg2rad(la1), phi2=deg2rad(la2);
+  const dphi=phi2-phi1, dl=deg2rad(lo2-lo1);
+  const a = Math.sin(dphi/2)**2 + Math.cos(phi1)*Math.cos(phi2)*Math.sin(dl/2)**2;
+  return 2*R_EARTH_NM*Math.asin(Math.sqrt(a));
+}
+
+export function parsePositions(boats, epsNm = EPSILON_NM) {
+  const out = {};
+  (boats || []).forEach(b => {
+    out[b.id] = dedupeMoments(b.moments || [], epsNm);
+  });
+  return out;
+}
+
+function dedupeMoments(moments, epsNm) {
+  const byTime = new Map();
+  const result = [];
+  for (const m of moments) {
+    const list = byTime.get(m.at) || [];
+    let dup = false;
+    for (const prev of list) {
+      if (haversineNm(prev.lat, prev.lon, m.lat, m.lon) <= epsNm) {
+        dup = true;
+        break;
+      }
+    }
+    if (!dup) {
+      list.push(m);
+      byTime.set(m.at, list);
+      result.push(m);
+    }
+  }
+  result.sort((a,b)=>a.at-b.at);
+  return result;
+}

--- a/test/parsePositions.test.mjs
+++ b/test/parsePositions.test.mjs
@@ -1,0 +1,17 @@
+import assert from 'assert';
+import { parsePositions } from '../parsePositions.mjs';
+
+const data = [
+  { id: 1, moments:[
+      { at: 1, lat: 10, lon: 20 },
+      { at: 1, lat: 10, lon: 20 },
+      { at: 2, lat: 10, lon: 20 },
+      { at: 2, lat: 10.1, lon: 20.1 },
+      { at: 3, lat: 11, lon: 21 }
+  ]}
+];
+
+const res = parsePositions(data, 0.005); // 0.005 nm tolerance (~10m)
+assert.equal(res[1].length, 4);
+assert.deepEqual(res[1].map(m => m.at), [1, 2, 2, 3]);
+console.log('ok');


### PR DESCRIPTION
## Summary
- de-duplicate race position fixes when loading
- switch to ES modules
- add a test for dedupe behavior
- document change in CHANGELOG

## Testing
- `node test/parsePositions.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6846c4cf56cc83249a9c87ee7a4ec02d