### PR TITLE
Fix Vite base path

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-  base: './',
+  base: '/',
 });


### PR DESCRIPTION
## Summary
- point `vite.config.ts` base path at the site root

## Testing
- `npm test` *(fails: npm not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6846eb0e2cec83248d4d930bb04b88ff