### PR TITLE
Add loading state for boat/class selectors

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,12 +26,12 @@
   </select>
 
   <!-- Boat chooser -->
-  <label for="boatSelect">Choose a boat:</label>
+  <label for="boatSelect">Choose a boat:</label><span id="boatStatus" style="margin-left:0.5rem"></span>
   <select id="boatSelect" disabled>
     <option value="">Select a race first</option>
   </select>
 
-  <label for="classSelect" style="margin-left:2rem">Choose a class:</label>
+  <label for="classSelect" style="margin-left:2rem">Choose a class:</label><span id="classStatus" style="margin-left:0.5rem"></span>
   <select id="classSelect" disabled>
     <option value="">Select a race first</option>
   </select>

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ const ctx         = (document.getElementById('speedChart') as HTMLCanvasElement)
 const rawToggle   = document.getElementById('rawToggle') as HTMLInputElement;
 const distInput   = document.getElementById('distInput') as HTMLInputElement;
 const percentileInput = document.getElementById('percentileInput') as HTMLInputElement;
+const boatStatus  = document.getElementById('boatStatus') as HTMLElement;
+const classStatus = document.getElementById('classStatus') as HTMLElement;
 
 let currentRace = '';
 let raceSetup: RaceSetup | null = null;
@@ -53,12 +55,19 @@ async function init(){
   if(!races.length) return;
   raceSelect.value = races[0].id;
   await loadRace(races[0].id);
-  raceSelect.addEventListener('change', () => {
+  raceSelect.addEventListener('change', async () => {
     if(!raceSelect.value){
       disableSelectors();
+      boatStatus.textContent = '';
+      classStatus.textContent = '';
       return;
     }
-    loadRace(raceSelect.value);
+    boatStatus.textContent = 'Loading...';
+    classStatus.textContent = 'Loading...';
+    disableSelectors();
+    await loadRace(raceSelect.value);
+    boatStatus.textContent = '';
+    classStatus.textContent = '';
   });
   distInput.value = String(settings.distNm);
   percentileInput.value = String(settings.percentile);


### PR DESCRIPTION
## Summary
- indicate when the app is loading race data by showing "Loading..." next to boat and class labels
- clear the message when data is ready

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684712fb15708324861357eef8270ee8