### PR TITLE
Improve network error handling

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,11 +14,19 @@
       --palette-6:#0065c1;
       --palette-7:#7e44a4;
     }
+    #error-container {
+      display: none;
+      border: 1px solid red;
+      color: red;
+      padding: 0.5rem;
+      margin: 1rem 0;
+    }
   </style>
 
 </head>
 <body>
   <h1 id="raceTitle">Coach Regatta</h1>
+  <div id="error-container"></div>
 
   <label for="raceSelect">Choose a race:</label>
   <select id="raceSelect">

--- a/src/raceLoader.ts
+++ b/src/raceLoader.ts
@@ -2,27 +2,60 @@ import { parsePositions } from './parsePositions';
 import type { RaceSetup, BoatData } from './types';
 import { DEFAULT_SETTINGS } from './speedUtils';
 
+function showError(msg: string){
+  const el = document.getElementById('error-container');
+  if(el){
+    el.textContent = msg;
+    (el as HTMLElement).style.display = 'block';
+  }
+}
+
+function clearError(){
+  const el = document.getElementById('error-container');
+  if(el){
+    el.textContent = '';
+    (el as HTMLElement).style.display = 'none';
+  }
+}
+
 export const settings = loadSettings();
 
 export async function fetchRaceSetup(raceId: string): Promise<RaceSetup> {
-  return fetchJSON<RaceSetup>(`/${raceId}/RaceSetup.json`);
+  try {
+    const data = await fetchJSON<RaceSetup>(`/${raceId}/RaceSetup.json`);
+    clearError();
+    return data;
+  } catch (err) {
+    console.error(err);
+    showError('Error: Could not load race data. Please check your connection and try again.');
+    throw err;
+  }
 }
 
 export async function fetchPositions(raceId: string, boatNames: number[]): Promise<Record<number, ReturnType<typeof parsePositions>[number]>> {
-  const all = await fetchJSON<BoatData[]>(`/${raceId}/AllPositions3.json`);
-  const filtered = all.filter(b => boatNames.includes(b.id));
-  return parsePositions(filtered);
+  try {
+    const all = await fetchJSON<BoatData[]>(`/${raceId}/AllPositions3.json`);
+    clearError();
+    const filtered = all.filter(b => boatNames.includes(b.id));
+    return parsePositions(filtered);
+  } catch (err) {
+    console.error(err);
+    showError('Error: Could not load race data. Please check your connection and try again.');
+    throw err;
+  }
 }
 
 export async function populateRaceSelector(): Promise<{ id: string; name: string }[]> {
   const raceSelect = document.getElementById('raceSelect') as HTMLSelectElement;
   try {
     const races = await fetchJSON<{ id: string; name: string }[]>('/races.json');
+    clearError();
     raceSelect.innerHTML = '';
     races.forEach(r => { const opt = document.createElement('option'); opt.value = r.id; opt.textContent = r.name; raceSelect.appendChild(opt); });
     return races;
   } catch (err) {
     console.error('Could not load races.json', err);
+    showError('Error: Could not load race data. Please check your connection and try again.');
     raceSelect.innerHTML = '<option value="">Could not load races</option>';
     raceSelect.disabled = true;
     return [];


### PR DESCRIPTION
## Summary
- highlight network errors on the page with a new `#error-container` element
- display loading failures for race data and hide the error when requests succeed

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684717b834a083249cf520e73267d4f2