### PR TITLE
Add interactive chart-leaderboard highlights

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,12 @@
       padding: 0.5rem;
       margin: 1rem 0;
     }
+    .lb-highlight {
+      background-color: #d2ebff;
+    }
+    .selected {
+      background-color: #ffef99;
+    }
   </style>
 
 </head>

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,5 +1,6 @@
 
 import type { LeaderboardEntry, Moment, CourseNode, SectorStat, RaceSetup } from './types';
+import { highlightSeries } from './chart';
 
 let leaderboardData: LeaderboardEntry[] = [];
 let classInfo: Record<string, { name: string; id: number; boats: number[] }> = {};
@@ -133,11 +134,17 @@ export function renderLeaderboard(classKey:string|null=null, boatId:number|null=
   let html='<table><thead><tr><th>Rank</th><th>Boat</th><th>Status</th><th>Corrected</th></tr></thead><tbody>';
   data.forEach(d=>{
     const name=boatNames[d.id] || `Boat ${d.id}`;
-    const highlight=d.id===boatId ? ' style="background-color:#ffef99"' : '';
-    html+=`<tr${highlight}><td>${d.rank ?? ''}</td><td>${name}</td><td>${d.status}</td><td>${d.corrected || ''}</td></tr>`;
+    const highlight=d.id===boatId ? ' class="selected"' : '';
+    html+=`<tr data-boat="${name}"${highlight}><td>${d.rank ?? ''}</td><td>${name}</td><td>${d.status}</td><td>${d.corrected || ''}</td></tr>`;
   });
   html+='</tbody></table>';
   container.innerHTML=html;
+
+  container.querySelectorAll('tr[data-boat]').forEach(tr=>{
+    const boat=(tr as HTMLElement).dataset.boat as string;
+    tr.addEventListener('mouseover',()=>{ highlightSeries(boat); });
+    tr.addEventListener('mouseout',()=>{ highlightSeries(null); });
+  });
 }
 
 export function clearSectorTable(){


### PR DESCRIPTION
## Summary
- highlight leaderbord rows and chart series on hover
- add hover styling classes
- link leaderboard rows to chart datasets

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684720c5d8908324acde38100ab5930b