### PR TITLE
Enable boat comparison mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -43,6 +43,10 @@
     <input type="checkbox" id="rawToggle" aria-label="Toggle raw points">
     Show raw points
   </label>
+  <label style="margin-left:2rem">
+    <input type="checkbox" id="compareToggle" aria-label="Enable comparison mode">
+    Enable Comparison Mode
+  </label>
 <details id="settingsDrawer" style="margin-top:1rem;" aria-label="Settings options">
   <summary>Settings</summary>
   <label>Glitch distance (nm):

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -46,8 +46,12 @@ export function destroyChart() {
 
 export interface Series { name: string; data: { x: Date; y: number }[] }
 
-export function renderChart(series: Series[]) {
+export function renderChart(series: Series[], selectedNames: string[] = []) {
   destroyChart();
+  if(selectedNames.length){
+    const set = new Set(selectedNames);
+    series = series.filter(s => set.has(s.name));
+  }
   const datasets = series.map((s, i) => ({
     label: s.name,
     data: s.data,


### PR DESCRIPTION
## Summary
- add comparison mode checkbox to UI
- toggle multiple selection on boat dropdown
- handle multiple boats in main logic
- filter chart datasets by selected boats

## Testing
- `npm run type-check`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68472d61b8ac8324808b0865952c0d3c