### PR TITLE
Improve speed calculations

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -161,7 +161,7 @@ async function loadRace(raceId:string){
   boatStats = {};
   ids.forEach(id => {
     const track = positions[id];
-    if(track) boatStats[id] = calculateBoatStatistics(track);
+    if(track) boatStats[id] = calculateBoatStatistics(track, settings);
   });
   displaySectorAnalysis(boatStats);
   drawTracks({}, []);

--- a/src/parsePositions.ts
+++ b/src/parsePositions.ts
@@ -13,7 +13,12 @@ export function haversineNm(la1:number, lo1:number, la2:number, lo2:number){
 export function parsePositions(boats: BoatData[], epsNm: number = EPSILON_NM): Record<number, Moment[]> {
   const out: Record<number, Moment[]> = {};
   (boats || []).forEach(b => {
-    out[b.id] = dedupeMoments(b.moments || [], epsNm);
+    const moments = (b.moments || []).map(m => ({
+      at: Number(m.at),
+      lat: Number(m.lat),
+      lon: Number(m.lon)
+    }));
+    out[b.id] = dedupeMoments(moments, epsNm);
   });
   return out;
 }

--- a/src/speedUtils.ts
+++ b/src/speedUtils.ts
@@ -73,22 +73,15 @@ function smooth(arr: number[], len: number): number[] {
   return out;
 }
 
-export function calculateBoatStatistics(track: Moment[]): { maxSpeed: number; avgSpeed: number } {
-  const moms = (track || []).slice().sort((a, b) => a.at - b.at);
+export function calculateBoatStatistics(track: Moment[], cfg: Partial<typeof DEFAULT_SETTINGS> = {}): { maxSpeed: number; avgSpeed: number } {
+  const settings = { ...DEFAULT_SETTINGS, ...cfg, smoothLen: 1 };
+  const { sogKn } = computeSeries(track, true, settings);
   let maxSpeed = 0;
   let sum = 0;
-  let count = 0;
-  for (let i = 1; i < moms.length; i++) {
-    const A = moms[i - 1];
-    const B = moms[i];
-    const dtHr = (B.at - A.at) / 3600;
-    if (dtHr <= 0) continue;
-    const dist = haversineNm(A.lat, A.lon, B.lat, B.lon);
-    const speed = dist / dtHr;
-    if (speed > maxSpeed) maxSpeed = speed;
-    sum += speed;
-    count++;
+  for (const s of sogKn) {
+    if (s > maxSpeed) maxSpeed = s;
+    sum += s;
   }
-  const avgSpeed = count ? sum / count : 0;
+  const avgSpeed = sogKn.length ? sum / sogKn.length : 0;
   return { maxSpeed, avgSpeed };
 }

--- a/test/calculateBoatStatistics.test.ts
+++ b/test/calculateBoatStatistics.test.ts
@@ -10,7 +10,7 @@ function makeTrack(){
   return pts;
 }
 
-const res = calculateBoatStatistics(makeTrack());
+const res = calculateBoatStatistics(makeTrack(), { distNm: Infinity, percentile: 100 });
 assert.ok(Math.abs(res.maxSpeed - 30) < 0.1);
 assert.ok(Math.abs(res.avgSpeed - (90/11)) < 0.1);
 console.log('ok');


### PR DESCRIPTION
## Summary
- ensure lat/lon/timestamps are parsed as numbers
- compute boat stats using filtered series
- allow configuration of boat statistic calculation in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684744102d8483248a2f251e72bc501b