### PR TITLE
Fix comparison mode update

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -89,7 +89,14 @@ let boatStats: Record<number, BoatStats> = {};
 let courseNodes: CourseNode[] = [];
 
 initChart({ ctx, chartTitleEl: chartTitle });
-initUI({ leaderboardDataRef: [], classInfoRef: {}, boatNamesRef: {}, positionsByBoatRef: {}, chartRef: null, chartTitleEl: chartTitle, boatSelectEl: boatSelect, classSelectEl: classSelect, rawToggleEl: rawToggle, sectorToggleEl: sectorToggle }, handleSelectionChange);
+initUI({ leaderboardDataRef: [], classInfoRef: {}, boatNamesRef: {}, positionsByBoatRef: {}, chartRef: null, chartTitleEl: chartTitle, boatSelectEl: boatSelect, classSelectEl: classSelect, rawToggleEl: rawToggle, sectorToggleEl: sectorToggle }, async (sel: any) => {
+  if(sel.comparison !== undefined){
+    setComparisonMode(sel.comparison);
+    await updateChart();
+    return;
+  }
+  await handleSelectionChange(sel);
+});
 disableSelectors();
 compareToggle.addEventListener('change', () => {
   comparisonMode = compareToggle.checked;
@@ -104,11 +111,7 @@ compareToggle.addEventListener('change', () => {
     setComparisonBoats([]);
   }
   refreshDropdowns();
-  if(boatSelect.value){
-    handleSelectionChange({ boat: boatSelect.value });
-  } else if(classSelect.value){
-    handleSelectionChange({ className: classSelect.value });
-  }
+  updateChart();
 });
 sectorToggle.addEventListener('change', drawSectorPolygons);
 
@@ -145,6 +148,14 @@ async function handleSelectionChange(sel:{ boat?: string; className?: string }){
   }
   renderChart(series, selectedNames, showSectors() ? sectorInfo : undefined);
   drawTracks(positions, ids);
+}
+
+async function updateChart(){
+  if(boatSelect.value){
+    await handleSelectionChange({ boat: boatSelect.value });
+  } else if(classSelect.value){
+    await handleSelectionChange({ className: classSelect.value });
+  }
 }
 
 async function loadRace(raceId:string){


### PR DESCRIPTION
## Summary
- handle comparison mode changes inside initUI callback
- update chart whenever comparison mode toggles
- add an `updateChart` helper to re-render based on current selection

## Testing
- `npm test`
- `npm run type-check` *(fails: Could not find a declaration file for module 'leaflet')*

------
https://chatgpt.com/codex/tasks/task_e_6848015557508324971c544883d70532