### PR TITLE
Update leaderboard on class selection

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,4 +1,4 @@
-import { fetchRaceSetup, fetchPositions, populateRaceSelector, settings, saveSettings } from './raceLoader';
+import { fetchRaceSetup, fetchPositions, populateRaceSelector, settings, saveSettings, fetchLeaderboard } from './raceLoader';
 import { initChart, renderChart, Series, computeSectorTimes } from './chart';
 import { initUI, updateUiWithRace, getClassInfo, getBoatId, getBoatNames, disableSelectors, displaySectorAnalysis, showSectors, setComparisonMode, isComparisonMode, getComparisonBoats, setComparisonBoats } from './ui';
 import { computeSeries, calculateBoatStatistics } from './speedUtils';
@@ -95,6 +95,12 @@ initUI({ leaderboardDataRef: [], classInfoRef: {}, boatNamesRef: {}, positionsBy
     await updateChart();
     return;
   }
+  if(sel.className){
+    settings.className = sel.className;
+    saveSettings();
+    const leaderboard = await fetchLeaderboard(currentRace);
+    if(raceSetup) updateUiWithRace(raceSetup, leaderboard);
+  }
   await handleSelectionChange(sel);
 });
 disableSelectors();
@@ -165,7 +171,8 @@ async function loadRace(raceId:string){
   courseNodes = raceSetup.course?.nodes || [];
   (window as any).courseNodes = courseNodes;
   drawSectorPolygons();
-  updateUiWithRace(raceSetup);
+  const leaderboard = await fetchLeaderboard(raceId);
+  updateUiWithRace(raceSetup, leaderboard);
   refreshDropdowns();
   const ids = raceSetup.teams.map(t => t.id);
   const positions = await fetchPositions(raceId, ids);

--- a/src/raceLoader.ts
+++ b/src/raceLoader.ts
@@ -1,5 +1,5 @@
 import { parsePositions } from './parsePositions';
-import type { RaceSetup, BoatData } from './types';
+import type { RaceSetup, BoatData, LeaderboardEntry } from './types';
 import { DEFAULT_SETTINGS } from './speedUtils';
 
 function showError(msg: string){
@@ -75,4 +75,22 @@ export async function fetchJSON<T>(url: string): Promise<T> {
   const r = await fetch(url).catch(err => { throw new Error(`${url}: ${err}`); });
   if(!r.ok) throw new Error(`${url}: ${r.status}`);
   return r.json() as Promise<T>;
+}
+
+export async function fetchLeaderboard(raceId: string): Promise<LeaderboardEntry[]> {
+  try {
+    const data = await fetchJSON<any>(`/${raceId}/leaderboard.json`);
+    clearError();
+    const teams = data?.tags?.[0]?.teams || [];
+    return teams.map((t: any) => ({
+      id: t.id,
+      rank: t.rankR ?? t.rankS,
+      status: t.status,
+      corrected: t.cElapsedFormatted
+    }));
+  } catch (err) {
+    console.error(err);
+    showError('Error: Could not load race data. Please check your connection and try again.');
+    return [];
+  }
 }

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -99,7 +99,8 @@ export function initUI(opts:{
   });
 }
 
-export function updateUiWithRace(setup: RaceSetup){
+export function updateUiWithRace(setup: RaceSetup, leaderboard: LeaderboardEntry[] = []){
+  leaderboardData = leaderboard.slice();
   nameToId = {};
   classInfo = {};
   boatNames = {};


### PR DESCRIPTION
## Summary
- add `fetchLeaderboard` helper
- pass leaderboard data to `updateUiWithRace`
- load leaderboard for current race
- refresh leaderboard when selecting a class

## Testing
- `npm test` *(fails: tsx not found)*
- `npx tsc --noEmit` *(fails: cannot find type definition file for 'vite/client')*

------
https://chatgpt.com/codex/tasks/task_e_68481643ef248324abbf21d7eb9e9724