### PR TITLE
Refactor layout grid

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,14 +61,18 @@
   </label>
 </details>
 
-  <!-- Chart and leaderboard area -->
-  <div id="main-content-container" style="display:flex; gap:2rem; align-items:flex-start; margin-top:2rem;">
-    <div id="chart-container">
-      <h2 id="chartTitle"></h2>
-      <canvas id="speedChart" width="900" height="400" role="img" aria-label="A line chart showing the speed of the boats over the duration of the race."></canvas>
+  <!-- Map, chart and leaderboard area -->
+  <div id="main-container">
+    <div id="map-wrapper">
       <div id="map-container" aria-label="Map showing boat tracks"></div>
     </div>
-    <div id="leaderboard-container"></div>
+    <div id="chart-wrapper">
+      <h2 id="chartTitle"></h2>
+      <canvas id="speedChart" role="img" aria-label="A line chart showing the speed of the boats over the duration of the race."></canvas>
+    </div>
+    <div id="table-wrapper">
+      <div id="leaderboard-container"></div>
+    </div>
   </div>
 
   <!-- Sector analysis area -->

--- a/styles.css
+++ b/styles.css
@@ -89,7 +89,31 @@ tr:hover {
 
 #map-container {
   width: 100%;
-  max-width: 900px;
+  height: 100%;
+}
+
+#main-container {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+
+#map-wrapper {
+  grid-area: 1 / 1 / 2 / 2;
   height: 400px;
-  margin-top: 1rem;
+}
+
+#chart-wrapper {
+  grid-area: 1 / 2 / 2 / 3;
+  height: 400px;
+}
+
+#table-wrapper {
+  grid-area: 2 / 1 / 3 / 3;
+}
+
+#chart-wrapper canvas {
+  width: 100%;
+  height: 100%;
 }


### PR DESCRIPTION
## Summary
- introduce a new `#main-container` grid to arrange map, chart, and leaderboard
- create wrappers for the map, chart, and table sections
- add grid and wrapper styles

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684947caa6a88324a5a855a415898682