### PR TITLE
Add moving average smoothing control

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,6 +51,15 @@
     <input type="checkbox" id="sectorToggle" aria-label="Toggle sector markers" checked>
     Show Sector Markers
   </label>
+  <label for="smoothing-selector" style="margin-left:2rem">Smoothing:</label>
+  <select id="smoothing-selector" aria-label="Smoothing interval">
+    <option value="0">None</option>
+    <option value="5">5 min</option>
+    <option value="10">10 min</option>
+    <option value="30">30 min</option>
+    <option value="60">1h</option>
+    <option value="120">2h</option>
+  </select>
 <details id="settingsDrawer" style="margin-top:1rem;" aria-label="Settings options">
   <summary>Settings</summary>
   <label>Glitch distance (nm):

--- a/src/speedUtils.ts
+++ b/src/speedUtils.ts
@@ -73,6 +73,19 @@ function smooth(arr: number[], len: number): number[] {
   return out;
 }
 
+export function applyMovingAverage(seriesData: {x:number, y:number}[], windowSize: number){
+  if(windowSize <= 1) return seriesData.slice();
+  const out: {x:number, y:number}[] = [];
+  let sum = 0;
+  for(let i=0;i<seriesData.length;i++){
+    sum += seriesData[i].y;
+    if(i >= windowSize) sum -= seriesData[i-windowSize].y;
+    const denom = i < windowSize ? i+1 : windowSize;
+    out.push({ x: seriesData[i].x, y: +(sum/denom).toFixed(2) });
+  }
+  return out;
+}
+
 export function calculateBoatStatistics(track: Moment[], cfg: Partial<typeof DEFAULT_SETTINGS> = {}): { maxSpeed: number; avgSpeed: number } {
   const settings = { ...DEFAULT_SETTINGS, ...cfg, smoothLen: 1 };
   const { sogKn } = computeSeries(track, true, settings);


### PR DESCRIPTION
## Summary
- add smoothing selector to HTML UI
- implement applyMovingAverage in speed utils
- centralize chart updates with `updateChartWithSelections`
- wire selectors to use new update function

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68494f464e408324b05fde28823df3b0