### PR TITLE
Enhance table data & UI layout

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -77,6 +77,7 @@ export function renderChart(series: Series[], selectedNames: string[] = [], sect
     data: { datasets } as any,
     options: {
       responsive: true,
+      maintainAspectRatio: false,
       scales: {
         x: { type: 'time', time: { unit: 'hour' }, grid: { color: 'rgba(0,0,0,0.06)', borderDash:[4,2] } },
         y: { title:{ display:true, text:'knots' }, grid:{ color:'rgba(0,0,0,0.06)', borderDash:[4,2] } }

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { fetchRaceSetup, fetchPositions, populateRaceSelector, settings, saveSettings, fetchLeaderboard } from './raceLoader';
 import { initChart, renderChart, Series, computeSectorTimes } from './chart';
-import { initUI, updateUiWithRace, getClassInfo, getBoatId, getBoatNames, disableSelectors, displaySectorAnalysis, showSectors, setComparisonMode, isComparisonMode, getComparisonBoats, setComparisonBoats, createUnifiedTable } from './ui';
-import { computeSeries, calculateBoatStatistics, averageSpeedsBySector, applyMovingAverage } from './speedUtils';
+import { initUI, updateUiWithRace, getClassInfo, getBoatId, getBoatNames, disableSelectors, showSectors, setComparisonMode, isComparisonMode, getComparisonBoats, setComparisonBoats, createUnifiedTable } from './ui';
+import { computeSeries, calculateBoatStatistics, averageSpeedsBySector, distancesBySector, applyMovingAverage } from './speedUtils';
 import { getColor } from './palette';
 import type { RaceSetup, BoatStats, Moment, CourseNode } from './types';
 import Choices from 'choices.js';
@@ -188,7 +188,6 @@ async function loadRace(raceId:string){
     const track = positions[id];
     if(track) boatStats[id] = calculateBoatStatistics(track, settings);
   });
-  displaySectorAnalysis(boatStats);
 
   const unifiedTableRows: any[] = [];
   leaderboard.forEach(entry => {
@@ -197,12 +196,14 @@ async function loadRace(raceId:string){
     const track = positions[id];
     const stats = boatStats[id];
     const sectorSpeeds = track ? averageSpeedsBySector(track, courseNodes) : [];
+    const sectorDistances = track ? distancesBySector(track, courseNodes) : [];
     unifiedTableRows.push({
       rank: entry.rank,
       boat: name,
       corrected: entry.corrected,
       topSpeed: stats?.maxSpeed ?? 0,
       totalAvgSpeed: stats?.avgSpeed ?? 0,
+      sectorDistances,
       avgSectorSpeeds: sectorSpeeds
     });
   });

--- a/src/speedUtils.ts
+++ b/src/speedUtils.ts
@@ -128,3 +128,29 @@ export function averageSpeedsBySector(moments: Moment[], nodes: CourseNode[]): n
   }
   return speeds;
 }
+
+export function distancesBySector(moments: Moment[], nodes: CourseNode[]): number[] {
+  const moms = moments.slice().sort((a,b)=>a.at-b.at);
+  if(!moms.length || !nodes.length) return [];
+  const dists: number[] = [];
+  for(let i=0;i<nodes.length-1;i++){
+    const start = nodes[i];
+    const end = nodes[i+1];
+    let startIdx: number | null = null, endIdx: number | null = null;
+    let startDist = Infinity, endDist = Infinity;
+    moms.forEach((m,idx)=>{
+      const ds = haversineNm(start.lat,start.lon,m.lat,m.lon);
+      if(ds < startDist){ startDist = ds; startIdx = idx; }
+      const de = haversineNm(end.lat,end.lon,m.lat,m.lon);
+      if(de < endDist){ endDist = de; endIdx = idx; }
+    });
+    if(startIdx===null || endIdx===null || endIdx<=startIdx) continue;
+    let dist = 0;
+    for(let j=startIdx+1;j<=endIdx;j++){
+      const A = moms[j-1], B = moms[j];
+      dist += haversineNm(A.lat,A.lon,B.lat,B.lon);
+    }
+    dists.push(dist);
+  }
+  return dists;
+}

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -263,14 +263,15 @@ export function createUnifiedTable(container: HTMLElement, tableData: any[]){
   if(!container) return;
   const table = document.createElement('table');
   const thead = document.createElement('thead');
-  thead.innerHTML = '<tr><th>Overall Rank</th><th>Boat</th><th>Corrected Time</th><th>Top Speed</th><th>Total Avg Speed</th><th>Avg Speed Per Sector</th></tr>';
+  thead.innerHTML = '<tr><th>Overall Rank</th><th>Boat</th><th>Corrected Time</th><th>Top Speed</th><th>Total Avg Speed</th><th>Distance Per Sector (nm)</th><th>Avg Speed Per Sector</th></tr>';
   table.appendChild(thead);
   const tbody = document.createElement('tbody');
   (tableData || []).forEach(row => {
     const tr = document.createElement('tr');
     tr.dataset.boat = row.boat;
+    const distSector = Array.isArray(row.sectorDistances) ? row.sectorDistances.map((n:number)=>n.toFixed(2)).join(', ') : '';
     const avgSector = Array.isArray(row.avgSectorSpeeds) ? row.avgSectorSpeeds.map((n:number)=>n.toFixed(2)).join(', ') : '';
-    tr.innerHTML = `<td>${row.rank ?? ''}</td><td>${row.boat}</td><td>${row.corrected ?? ''}</td><td>${row.topSpeed?.toFixed ? row.topSpeed.toFixed(2) : row.topSpeed}</td><td>${row.totalAvgSpeed?.toFixed ? row.totalAvgSpeed.toFixed(2) : row.totalAvgSpeed}</td><td>${avgSector}</td>`;
+    tr.innerHTML = `<td>${row.rank ?? ''}</td><td>${row.boat}</td><td>${row.corrected ?? ''}</td><td>${row.topSpeed?.toFixed ? row.topSpeed.toFixed(2) : row.topSpeed}</td><td>${row.totalAvgSpeed?.toFixed ? row.totalAvgSpeed.toFixed(2) : row.totalAvgSpeed}</td><td>${distSector}</td><td>${avgSector}</td>`;
     tr.addEventListener('mouseover', ()=>{ highlightSeries(row.boat); });
     tr.addEventListener('mouseout', ()=>{ highlightSeries(null); });
     tbody.appendChild(tr);

--- a/styles.css
+++ b/styles.css
@@ -117,3 +117,11 @@ tr:hover {
   width: 100%;
   height: 100%;
 }
+
+.choices {
+  z-index: 1000;
+}
+
+.choices__list--dropdown {
+  z-index: 1001;
+}


### PR DESCRIPTION
## Summary
- compute distance per sector for tracks
- expose sector distances in race table
- allow speed chart to fill its container
- ensure dropdowns overlay the map
- drop the unused max-speed table

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849567afb348324ae8fd0194837022d