### PR TITLE
Add sector distance/speed graphs

### DIFF
--- a/index.html
+++ b/index.html
@@ -79,6 +79,14 @@
       <h2 id="chartTitle"></h2>
       <canvas id="speedChart" role="img" aria-label="A line chart showing the speed of the boats over the duration of the race."></canvas>
     </div>
+    <div id="dist-chart-wrapper">
+      <h2>Distance Per Sector (nm)</h2>
+      <canvas id="distSectorChart" role="img" aria-label="Distance sailed per sector"></canvas>
+    </div>
+    <div id="avg-chart-wrapper">
+      <h2>Avg Speed Per Sector</h2>
+      <canvas id="avgSectorChart" role="img" aria-label="Average speed per sector"></canvas>
+    </div>
     <div id="table-wrapper">
       <div id="leaderboard-container"></div>
     </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@types/chroma-js": "^3.1.1",
+        "@types/leaflet": "^1.9.18",
         "chartjs-node-canvas": "^5.0.0",
         "get-contrast": "^3.0.0",
         "pixelmatch": "^5.3.0",
@@ -748,11 +749,28 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/hammerjs": {
       "version": "2.0.46",
       "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
       "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.18",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.18.tgz",
+      "integrity": "sha512-ht2vsoPjezor5Pmzi5hdsA7F++v5UGq9OlUduWHmMZiuQGIpJ2WS5+Gg9HaAA79gNh1AIPtCqhzejcIZ3lPzXQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   },
   "devDependencies": {
     "@types/chroma-js": "^3.1.1",
+    "@types/leaflet": "^1.9.18",
     "chartjs-node-canvas": "^5.0.0",
     "get-contrast": "^3.0.0",
     "pixelmatch": "^5.3.0",

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -167,3 +167,42 @@ const sectorPlugin = {
   }
 };
 
+let distCtx: CanvasRenderingContext2D;
+let avgCtx: CanvasRenderingContext2D;
+let distChart: any = null;
+let avgChart: any = null;
+
+export function initSectorCharts(opts:{distCtx:CanvasRenderingContext2D; avgCtx:CanvasRenderingContext2D;}){
+  distCtx = opts.distCtx;
+  avgCtx = opts.avgCtx;
+}
+
+export function clearSectorCharts(){
+  if(distChart){ distChart.destroy(); distChart=null; }
+  if(avgChart){ avgChart.destroy(); avgChart=null; }
+}
+
+function renderSimpleChart(ctx:CanvasRenderingContext2D, chartRef:any, labels:string[],
+  dataSeries:{name:string; data:number[]}[], yLabel:string){
+  if(chartRef){ chartRef.destroy(); }
+  const lineWidth = dataSeries.length > 5 ? 1 : 2;
+  const datasets = dataSeries.map((s,i)=>({
+    label:s.name,
+    data:s.data,
+    borderColor:getColor(i),
+    backgroundColor:getColor(i),
+    borderWidth: lineWidth,
+    pointRadius:0,
+    tension:0
+  }));
+  return new Chart(ctx,{type:'line',data:{labels,datasets},options:{responsive:true,maintainAspectRatio:false,scales:{x:{grid:{color:'rgba(0,0,0,0.06)',borderDash:[4,2]}},y:{title:{display:true,text:yLabel},grid:{color:'rgba(0,0,0,0.06)',borderDash:[4,2]}}}} as any});
+}
+
+export function renderDistancePerSector(labels:string[], series:{name:string; data:number[]}[]){
+  distChart = renderSimpleChart(distCtx, distChart, labels, series, 'nm');
+}
+
+export function renderSpeedPerSector(labels:string[], series:{name:string; data:number[]}[]){
+  avgChart = renderSimpleChart(avgCtx, avgChart, labels, series, 'kn');
+}
+

--- a/src/leaflet.d.ts
+++ b/src/leaflet.d.ts
@@ -1,0 +1,1 @@
+declare module 'leaflet';

--- a/styles.css
+++ b/styles.css
@@ -95,6 +95,7 @@ tr:hover {
 #main-container {
   display: grid;
   grid-template-columns: 1fr 1fr;
+  grid-template-rows: auto auto auto;
   gap: 1rem;
   margin-top: 2rem;
 }
@@ -109,11 +110,27 @@ tr:hover {
   height: 400px;
 }
 
+#dist-chart-wrapper {
+  grid-area: 2 / 1 / 3 / 2;
+  height: 300px;
+}
+
+#avg-chart-wrapper {
+  grid-area: 2 / 2 / 3 / 3;
+  height: 300px;
+}
+
 #table-wrapper {
-  grid-area: 2 / 1 / 3 / 3;
+  grid-area: 3 / 1 / 4 / 3;
 }
 
 #chart-wrapper canvas {
+  width: 100%;
+  height: 100%;
+}
+
+#dist-chart-wrapper canvas,
+#avg-chart-wrapper canvas {
   width: 100%;
   height: 100%;
 }


### PR DESCRIPTION
## Summary
- layout: add two new chart areas for distance and speed per sector
- style: grid for new charts
- charts: add distance/speed sector rendering logic
- script: render sector charts based on current selection
- add TypeScript typings for leaflet

## Testing
- `npm run type-check`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684959c18dfc83248926cddd172f4390