### PR TITLE
Fix mobile layout for controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,6 +24,8 @@
   <h1 id="raceTitle">Coach Regatta</h1>
   <div id="error-container"></div>
 
+  <div id="controls-container">
+
   <label for="raceSelect">Choose a race:</label>
   <select id="raceSelect" aria-label="Choose a race to display">
     <option value="">Loading…</option>
@@ -70,6 +72,8 @@
     <input type="number" id="percentileInput" step="1" min="50" max="100" aria-label="Speed ceiling percentile">
   </label>
 </details>
+
+  </div>
 
   <!-- Map, chart and leaderboard area -->
   <div id="main-container">

--- a/styles.css
+++ b/styles.css
@@ -61,6 +61,14 @@ input[type='number']:focus {
   border-radius: 4px;
 }
 
+#controls-container {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  position: relative;
+  z-index: 10;
+}
+
 .lb-highlight {
   background-color: #d2ebff;
 }


### PR DESCRIPTION
## Summary
- group UI controls in `index.html`
- style the new container so controls wrap on small screens and appear above the map

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6849e4c4a6fc8324ab91e71a160af376