### PR TITLE
Add mobile filter panel

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,11 +25,13 @@
   <div id="error-container"></div>
 
   <div id="controls-container">
+    <button id="filter-toggle-button">Filters</button>
+    <div id="filter-panel">
 
-  <label for="raceSelect">Choose a race:</label>
-  <select id="raceSelect" aria-label="Choose a race to display">
-    <option value="">Loading…</option>
-  </select>
+    <label for="raceSelect">Choose a race:</label>
+    <select id="raceSelect" aria-label="Choose a race to display">
+      <option value="">Loading…</option>
+    </select>
 
   <!-- Boat chooser -->
   <label for="boatSelect">Choose a boat:</label><span id="boatStatus" style="margin-left:0.5rem"></span>
@@ -75,6 +77,8 @@
   </label>
 </details>
 
+
+  </div>
   </div>
 
   <!-- Map, chart and leaderboard area -->

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -281,3 +281,13 @@ export function createUnifiedTable(container: HTMLElement, tableData: any[]){
   container.appendChild(table);
 }
 
+window.addEventListener('DOMContentLoaded', () => {
+  const toggleBtn = document.getElementById('filter-toggle-button');
+  const panel = document.getElementById('filter-panel');
+  if(toggleBtn && panel){
+    toggleBtn.addEventListener('click', () => {
+      panel.classList.toggle('is-open');
+    });
+  }
+});
+

--- a/styles.css
+++ b/styles.css
@@ -62,11 +62,19 @@ input[type='number']:focus {
 }
 
 #controls-container {
+  position: relative;
+  z-index: 10;
+}
+
+#filter-panel {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  position: relative;
-  z-index: 10;
+}
+
+#filter-toggle-button {
+  display: none;
+  margin-bottom: 0.5rem;
 }
 
 .lb-highlight {
@@ -175,5 +183,27 @@ tr:hover {
   #dist-chart-wrapper,
   #avg-chart-wrapper {
     margin-bottom: 2rem;
+  }
+}
+
+@media (max-width: 768px) {
+  #filter-toggle-button {
+    display: block;
+  }
+
+  #filter-panel {
+    display: none;
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: #fff;
+    padding: 1rem;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+    z-index: 100;
+  }
+
+  #filter-panel.is-open {
+    display: flex;
   }
 }


### PR DESCRIPTION
## Summary
- add new `filter-panel` container and toggle button in `index.html`
- style filter panel for mobile and hide behind `Filters` button
- toggle filter panel open state via JavaScript

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6849eda0dc788324aacf8dcdf16aa26a