### PR TITLE
Add tooltip showing all boat speeds

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -111,6 +111,21 @@ export function renderChart(series: Series[], selectedNames: string[] = [], sect
         }
       },
       plugins:{
+        tooltip:{
+          mode:'index',
+          intersect:false,
+          callbacks:{
+            beforeBody(tooltipItems:any[]){
+              const lines:string[] = [];
+              tooltipItems.forEach(item=>{
+                const label = (item.dataset as any)?.label || item.datasetLabel || '';
+                lines.push(`${label}: ${item.formattedValue} knots`);
+              });
+              return lines;
+            },
+            label(){ return ''; }
+          }
+        },
         zoom:{
           zoom:{ wheel:{ enabled:true }, pinch:{ enabled:true }, mode:'x' },
           pan:{ enabled:true, mode:'x' },


### PR DESCRIPTION
## Summary
- enhance chart tooltip configuration to display speeds of all datasets at a hover point

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6849f0f1908483249fe1a0cd401cf5df