### PR TITLE
Implement race replay controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -98,8 +98,18 @@
       <h2>Avg Speed Per Sector</h2>
       <canvas id="avgSectorChart" role="img" aria-label="Average speed per sector"></canvas>
     </div>
-    <div id="table-wrapper">
+  <div id="table-wrapper">
       <div id="leaderboard-container"></div>
+  </div>
+  </div>
+
+  <div id="replay-controls">
+    <input id="timeline-scrubber" type="range" value="0" min="0" step="1">
+    <button id="play-pause-btn">Play</button>
+    <div id="speed-controls">
+      <button id="speed-1x">1x</button>
+      <button id="speed-2x">2x</button>
+      <button id="speed-4x">4x</button>
     </div>
   </div>
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,8 @@
 import { fetchRaceSetup, fetchPositions, populateRaceSelector, settings, saveSettings, fetchLeaderboard } from './raceLoader';
 import { initChart, renderChart, Series, computeSectorTimes,
   initSectorCharts, renderDistancePerSector, renderSpeedPerSector,
-  clearSectorCharts, highlightChartLine } from './chart';
+  clearSectorCharts, highlightChartLine,
+  initMapReplay, setReplayData, updateBoatPositionsAtTime } from './chart';
 import { initUI, updateUiWithRace, getClassInfo, getBoatId, getBoatNames, disableSelectors, showSectors, setComparisonMode, isComparisonMode, getComparisonBoats, setComparisonBoats, createUnifiedTable } from './ui';
 import { computeSeries, calculateBoatStatistics, averageSpeedsBySector, distancesBySector, applyMovingAverage } from './speedUtils';
 import { getColor } from './palette';
@@ -32,6 +33,12 @@ L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
   attribution: '© OpenStreetMap'
 }).addTo(map);
 map.setView([0, 0], 2);
+initMapReplay(map);
+let isPlaying = false;
+let replaySpeed = 1;
+let currentTime = 0;
+let raceData: Record<number, Moment[]> = {};
+let lastFrame = 0;
 let polylines: { id: number; poly: L.Polyline }[] = [];
 let sectorPolygons: any[] = [];
 
@@ -111,6 +118,24 @@ function refreshDropdowns(){
   boatChoices = new Choices(boatSelect, { searchEnabled: true, shouldSort: false });
   classChoices = new Choices(classSelect, { searchEnabled: true, shouldSort: false });
 }
+
+export function animationLoop(ts: number){
+  requestAnimationFrame(animationLoop);
+  if(!isPlaying){ lastFrame = ts; return; }
+  if(!lastFrame) lastFrame = ts;
+  const dt = (ts - lastFrame) / 1000;
+  lastFrame = ts;
+  currentTime += dt * replaySpeed;
+  updateBoatPositionsAtTime(currentTime);
+  const scrubber = document.getElementById('timeline-scrubber') as HTMLInputElement;
+  if(scrubber) scrubber.value = String(currentTime);
+}
+
+export function play(){ isPlaying = true; }
+export function pause(){ isPlaying = false; }
+export function togglePlayPause(){ isPlaying ? pause() : play(); }
+export function setSpeed(speed: number){ replaySpeed = speed; }
+export function scrubToTime(t: number){ currentTime = Number(t); updateBoatPositionsAtTime(currentTime); }
 
 let currentRace = '';
 let raceSetup: RaceSetup | null = null;
@@ -233,6 +258,19 @@ async function loadRace(raceId:string){
   refreshDropdowns();
   const ids = raceSetup.teams.map(t => t.id);
   const positions = await fetchPositions(raceId, ids);
+  raceData = positions;
+  setReplayData(raceData);
+  const times:number[] = [];
+  Object.values(positions).forEach(track=>track.forEach(m=>times.push(m.at)));
+  times.sort((a,b)=>a-b);
+  const scrubber=document.getElementById('timeline-scrubber') as HTMLInputElement;
+  if(times.length && scrubber){
+    scrubber.min=String(times[0]);
+    scrubber.max=String(times[times.length-1]);
+    currentTime=times[0];
+    scrubber.value=String(currentTime);
+    updateBoatPositionsAtTime(currentTime);
+  }
   Object.keys(positionsByBoat).forEach(k=>delete (positionsByBoat as any)[k]);
   Object.assign(positionsByBoat, positions);
   boatStats = {};
@@ -292,3 +330,4 @@ async function init(){
 }
 
 window.addEventListener('DOMContentLoaded', init);
+requestAnimationFrame(animationLoop);

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -1,7 +1,7 @@
 
 import type { LeaderboardEntry, Moment, CourseNode, SectorStat, RaceSetup } from './types';
 import { highlightSeries } from './chart';
-import { setHighlightedBoatId } from './main';
+import { setHighlightedBoatId, togglePlayPause, setSpeed, scrubToTime } from './main';
 
 let leaderboardData: LeaderboardEntry[] = [];
 let classInfo: Record<string, { name: string; id: number; boats: number[] }> = {};
@@ -13,6 +13,11 @@ let boatSelect: HTMLSelectElement;
 let classSelect: HTMLSelectElement;
 let rawToggle: HTMLInputElement;
 let sectorToggle: HTMLInputElement;
+let playPauseBtn: HTMLButtonElement;
+let timelineScrubber: HTMLInputElement;
+let speed1x: HTMLButtonElement;
+let speed2x: HTMLButtonElement;
+let speed4x: HTMLButtonElement;
 let selectionCb: (sel:{boat?:string; className?:string})=>void = ()=>{};
 let nameToId: Record<string, number> = {};
 let comparisonMode = false;
@@ -66,6 +71,11 @@ export function initUI(opts:{
   classSelect = opts.classSelectEl;
   rawToggle = opts.rawToggleEl;
   sectorToggle = opts.sectorToggleEl;
+  playPauseBtn = document.getElementById('play-pause-btn') as HTMLButtonElement;
+  timelineScrubber = document.getElementById('timeline-scrubber') as HTMLInputElement;
+  speed1x = document.getElementById('speed-1x') as HTMLButtonElement;
+  speed2x = document.getElementById('speed-2x') as HTMLButtonElement;
+  speed4x = document.getElementById('speed-4x') as HTMLButtonElement;
   selectionCb = onSelect;
   boatSelect.addEventListener('change', () => {
     if(boatSelect.hasAttribute('multiple')){
@@ -98,6 +108,21 @@ export function initUI(opts:{
       selectionCb({ className: classSelect.value });
     }
   });
+
+  if(playPauseBtn){
+    playPauseBtn.addEventListener('click', () => {
+      togglePlayPause();
+      playPauseBtn.textContent = playPauseBtn.textContent === 'Play' ? 'Pause' : 'Play';
+    });
+  }
+  if(timelineScrubber){
+    timelineScrubber.addEventListener('input', () => {
+      scrubToTime(Number(timelineScrubber.value));
+    });
+  }
+  if(speed1x) speed1x.addEventListener('click', () => setSpeed(1));
+  if(speed2x) speed2x.addEventListener('click', () => setSpeed(2));
+  if(speed4x) speed4x.addEventListener('click', () => setSpeed(4));
 }
 
 export function updateUiWithRace(setup: RaceSetup, leaderboard: LeaderboardEntry[] = []){

--- a/styles.css
+++ b/styles.css
@@ -144,6 +144,21 @@ tr:hover {
   grid-area: 3 / 1 / 4 / 3;
 }
 
+#replay-controls {
+  margin-top: 1rem;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+#replay-controls input[type="range"] {
+  flex: 1;
+}
+
+#speed-controls button {
+  margin-right: 0.25rem;
+}
+
 #chart-wrapper canvas {
   width: 100%;
   height: 100%;


### PR DESCRIPTION
## Summary
- add UI controls for timeline playback
- style replay controls
- add replay state and animation loop
- expose functions to manage replay from UI
- update map markers at the selected time

## Testing
- `npm test` *(fails: tsx not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849f38bbe3c8324bb3626b404dc7ebb