### PR TITLE
Update styles for overlay layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -38,6 +38,38 @@ button {
   box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
 }
 
+#app {
+    position: relative;
+    height: 100%;
+    width: 100%;
+}
+
+#map {
+    height: 100%;
+    width: 100%;
+}
+
+.info-pane {
+    position: absolute;
+    top: 20px;
+    left: 20px;
+    width: 350px;
+    padding: 1rem;
+    box-sizing: border-box;
+    background-color: white;
+    border-radius: 8px;
+    box-shadow: 0 4px 8px rgba(0,0,0,0.15);
+    z-index: 1000;
+}
+
+#race-selector,
+#boat-selector,
+#class-selector {
+    width: 100%;
+    padding: 8px;
+    box-sizing: border-box;
+}
+
 button:hover,
 button:focus {
   background-color: var(--palette-6);
@@ -191,23 +223,21 @@ tr:hover {
 }
 
 @media (max-width: 768px) {
-  #filter-toggle-button {
-    display: block;
-  }
+    #app {
+        display: flex;
+        flex-direction: column;
+    }
 
-  #filter-panel {
-    display: none;
-    position: absolute;
-    top: 100%;
-    left: 0;
-    right: 0;
-    background: #fff;
-    padding: 1rem;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-    z-index: 100;
-  }
+    #map {
+        width: 100%;
+        height: 50%;
+    }
 
-  #filter-panel.is-open {
-    display: flex;
-  }
+    .info-pane {
+        position: static;
+        width: 100%;
+        height: 50%;
+        box-shadow: none;
+        border-radius: 0;
+    }
 }


### PR DESCRIPTION
## Summary
- overlay the info panel on desktop
- widen dropdown selectors
- reset panel position for mobile layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ae5afaba08324bdb08dd7b624e7a8