### PR TITLE
Fix dropdown z-index and prevent wrapping

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -192,22 +192,18 @@ tr:hover {
 }
 
 .choices.is-open {
-  z-index: 20;
+  z-index: 1002; /* Increased from 20 to a high value */
 }
 
 .choices__list--dropdown {
   z-index: 1001;
 }
 
-/* Prevent word wrapping of boat and class names in dropdowns */
-#boatSelect + .choices .choices__item,
-#boatSelect + .choices .choices__list--dropdown,
+/* Correctly prevent word wrapping in the dropdown list */
 #boatSelect + .choices .choices__list--dropdown .choices__item,
-#classSelect + .choices .choices__item,
-#classSelect + .choices .choices__list--dropdown,
 #classSelect + .choices .choices__list--dropdown .choices__item {
-  word-break: normal;
-  white-space: nowrap;
+  white-space: nowrap; /* Prevents text from wrapping */
+  word-break: keep-all; /* Alternative for good measure */
 }
 
 /* Ensure boat and class dropdowns have a reasonable width */


### PR DESCRIPTION
## Summary
- keep dropdowns from being hidden behind other elements
- make sure boat and class names don't wrap inside the dropdown

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_684de08953f08324b609616f4966bcbf