### PR TITLE
Add legend toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,6 +61,10 @@
     <input type="checkbox" id="sectorToggle" aria-label="Toggle sector markers" checked>
     Show Sector Markers
   </label>
+  <label style="margin-left:2rem">
+    <input type="checkbox" id="legendToggle" aria-label="Toggle chart legends">
+    Show Legends
+  </label>
   <div>
     <label for="smoothing-selector" style="margin-left:2rem">Smoothing:</label>
     <select id="smoothing-selector" aria-label="Smoothing interval">

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -112,6 +112,7 @@ export function renderChart(series: Series[], selectedNames: string[] = [], sect
         }
       },
       plugins:{
+        legend:{ display: legendVisible },
         tooltip:{
           mode:'index',
           intersect:false,
@@ -202,6 +203,16 @@ let distCtx: CanvasRenderingContext2D;
 let avgCtx: CanvasRenderingContext2D;
 let distChart: any = null;
 let avgChart: any = null;
+let legendVisible = false;
+
+export function setLegendVisibility(v: boolean){
+  legendVisible = v;
+  if(chart){ chart.options.plugins.legend.display = legendVisible; chart.update(); }
+  if(distChart){ distChart.options.plugins.legend.display = legendVisible; distChart.update(); }
+  if(avgChart){ avgChart.options.plugins.legend.display = legendVisible; avgChart.update(); }
+}
+
+export function isLegendVisible(){ return legendVisible; }
 
 export function initSectorCharts(opts:{distCtx:CanvasRenderingContext2D; avgCtx:CanvasRenderingContext2D;}){
   distCtx = opts.distCtx;
@@ -230,7 +241,7 @@ function renderSimpleChart(ctx:CanvasRenderingContext2D, chartRef:any, labels:st
   return new Chart(ctx,{type:'line',data:{labels,datasets},options:{responsive:true,maintainAspectRatio:false,
     interaction:{mode:'nearest',intersect:false},
     scales:{x:{grid:{color:'rgba(0,0,0,0.06)',borderDash:[4,2]}},y:{title:{display:true,text:yLabel},grid:{color:'rgba(0,0,0,0.06)',borderDash:[4,2]}}},
-    plugins:{tooltip:{mode:'index',intersect:false,callbacks:{beforeBody(tooltipItems: TooltipItem<'line'>[]){
+    plugins:{legend:{display:legendVisible},tooltip:{mode:'index',intersect:false,callbacks:{beforeBody(tooltipItems: TooltipItem<'line'>[]){
       const lines:string[]=[];
       tooltipItems.forEach(item=>{
         const label=item.dataset?.label ?? '';

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 import { fetchRaceSetup, fetchPositions, populateRaceSelector, settings, saveSettings, fetchLeaderboard } from './raceLoader';
 import { initChart, renderChart, Series, computeSectorTimes,
   initSectorCharts, renderDistancePerSector, renderSpeedPerSector,
-  clearSectorCharts, highlightChartLine } from './chart';
+  clearSectorCharts, highlightChartLine, setLegendVisibility } from './chart';
 import { initUI, updateUiWithRace, getClassInfo, getBoatId, getBoatNames, disableSelectors, showSectors, setComparisonMode, isComparisonMode, getComparisonBoats, setComparisonBoats, createUnifiedTable } from './ui';
 import { computeSeries, calculateBoatStatistics, averageSpeedsBySector, distancesBySector, applyMovingAverage } from './speedUtils';
 import { getColor } from './palette';
@@ -21,6 +21,7 @@ const avgCtx      = (document.getElementById('avgSectorChart') as HTMLCanvasElem
 const rawToggle   = document.getElementById('rawToggle') as HTMLInputElement;
 const compareToggle = document.getElementById('compareToggle') as HTMLInputElement;
 const sectorToggle = document.getElementById('sectorToggle') as HTMLInputElement;
+const legendToggle = document.getElementById('legendToggle') as HTMLInputElement;
 const smoothingSelect = document.getElementById('smoothing-selector') as HTMLSelectElement;
 const distInput   = document.getElementById('distInput') as HTMLInputElement;
 const percentileInput = document.getElementById('percentileInput') as HTMLInputElement;
@@ -159,6 +160,7 @@ compareToggle.addEventListener('change', () => {
 });
 sectorToggle.addEventListener('change', drawSectorPolygons);
 smoothingSelect.addEventListener('change', updateChartWithSelections);
+legendToggle.addEventListener('change', () => setLegendVisibility(legendToggle.checked));
 
 async function updateChartWithSelections(){
   if(!currentRace || !raceSetup) return;
@@ -269,6 +271,7 @@ async function init(){
   const races = await populateRaceSelector();
   if(!races.length) return;
   refreshDropdowns();
+  setLegendVisibility(legendToggle.checked);
   raceSelect.value = races[0].id;
   await loadRace(races[0].id);
   raceSelect.addEventListener('change', async () => {


### PR DESCRIPTION
## Summary
- hide legends on all charts by default
- add a checkbox to show/hide chart legends
- allow runtime toggling for existing charts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856a7117b808324afe0ed66aa2e0588