### PR TITLE
Improve legend toggle styling and function

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,7 +61,7 @@
     <input type="checkbox" id="sectorToggle" aria-label="Toggle sector markers" checked>
     Show Sector Markers
   </label>
-  <label style="margin-left:2rem">
+  <label class="legend-toggle-label">
     <input type="checkbox" id="legendToggle" aria-label="Toggle chart legends">
     Show Legends
   </label>

--- a/src/chart.ts
+++ b/src/chart.ts
@@ -205,11 +205,14 @@ let distChart: any = null;
 let avgChart: any = null;
 let legendVisible = false;
 
-export function setLegendVisibility(v: boolean){
+export function setLegendVisibility(v: boolean) {
   legendVisible = v;
-  if(chart){ chart.options.plugins.legend.display = legendVisible; chart.update(); }
-  if(distChart){ distChart.options.plugins.legend.display = legendVisible; distChart.update(); }
-  if(avgChart){ avgChart.options.plugins.legend.display = legendVisible; avgChart.update(); }
+  [chart, distChart, avgChart].forEach(c => {
+    if (c) {
+      c.options.plugins.legend.display = legendVisible;
+      c.update();
+    }
+  });
 }
 
 export function isLegendVisible(){ return legendVisible; }

--- a/styles.css
+++ b/styles.css
@@ -199,6 +199,11 @@ tr:hover {
   min-width: 18ch;
 }
 
+/* Styling for the legend toggle label */
+.legend-toggle-label {
+  margin-left: 2rem;
+}
+
 @media (max-width: 600px) {
   #main-container {
     display: flex;


### PR DESCRIPTION
## Summary
- move inline legend toggle style into `.legend-toggle-label` CSS class
- use the new class in `index.html`
- refactor `setLegendVisibility` to iterate over all charts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6856d72420848324853218890fa9bf94