### PR TITLE
Fix legend update check

### DIFF
--- a/src/chart.ts
+++ b/src/chart.ts
@@ -208,7 +208,7 @@ let legendVisible = false;
 export function setLegendVisibility(v: boolean) {
   legendVisible = v;
   [chart, distChart, avgChart].forEach(c => {
-    if (c) {
+    if (c && typeof (c as any).update === 'function') {
       c.options.plugins.legend.display = legendVisible;
       c.update();
     }


### PR DESCRIPTION
## Summary
- guard each chart before updating legend visibility by checking the `update` method exists

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685704f26ea88324ba46e816d730af0b